### PR TITLE
SSL client certificate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Bug reports and pull requests are welcomed.
 
   - **An option to inject custom JavaScript code into web pages** (default off). The code is executed after the web page has finished loading.
 
+  - **Allow web pages to request SSL client certificates** (default off). Allows the web page to request an SSL client certificate, that is present in the user's certificate store, with an option to specify the name and issuer of the certificate that will be sent. 
+
   - **An option to ignore certificate errors** (default off). Note that this is highly insecure so only enable this option when you absolutely trust the website (for example, a website self-signed by yourself).
 
 - **Transparent background** (default off). This option is configurable in edit mode.

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -75,5 +75,11 @@
     <entry name="customJS" type="String">
       <default></default>
     </entry>
+    <entry name="allowClientCertificates" type="Bool">
+      <default>false</default>
+    </entry>
+    <entry name="clientCert" type="String">
+      <default></default>
+    </entry>
   </group>
 </kcfg>

--- a/contents/ui/ConfigGeneral.qml
+++ b/contents/ui/ConfigGeneral.qml
@@ -24,6 +24,9 @@ KCM.SimpleKCM {
     property alias cfg_useCustomJS: useCustomJS.checked
     property alias cfg_customJS: customJS.text
 
+    property alias cfg_allowClientCertificates: allowClientCertificates.checked
+    property alias cfg_clientCert: clientCert.text
+
     Kirigami.FormLayout {
         QQC2.ButtonGroup { id: defaultUrlGroup }
 
@@ -238,6 +241,20 @@ KCM.SimpleKCM {
             placeholderText: i18nc("@info", "(()=>{ alert() })()")
             enabled: useCustomJS.checked
             Accessible.description: text.length > 0 ? text : i18nc("@info", "Custom JavaScript content")
+        }
+
+        QQC2.CheckBox {
+            id: allowClientCertificates
+            Kirigami.FormData.label: i18nc("@title:group", "Client certificate:")
+            text: i18nc("@option:check", "Allow web page to request a client certificate")
+        }
+
+        PlasmaComponents3.TextField {
+            id: clientCert
+            Layout.fillWidth: true
+            placeholderText: i18nc("@info", "Company, Inc.|ThisPC")
+            enabled: allowClientCertificates.checked
+            Accessible.description: text.length > 0 ? text : i18nc("@info", "Certificate name")
         }
     }
 }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -328,6 +328,28 @@ PlasmoidItem {
                     }
                 }
 
+                onSelectClientCertificate: clientCertificateSelection => {
+                    console.log("Got cert prompt")
+                    if (!plasmoid.configuration.allowClientCertificates) {
+                        clientCertificateSelection.selectNone();
+                        return;
+                    }
+
+                    clientCertificateSelection.certificates.forEach(e => {
+                        console.log(`${e.issuer}|${e.subject}`);
+                    })
+
+                    var idx = clientCertificateSelection.certificates.findIndex(e => `${e.issuer}|${e.subject}` == plasmoid.configuration.clientCert)
+                    console.log("selected cert: " + idx);
+                    if (idx == -1)
+                    {
+                        clientCertificateSelection.selectNone();
+                        return;
+                    }
+
+                    clientCertificateSelection.select(idx);
+                }
+
                 onLinkHovered: hoveredUrl => {
                     if (hoveredUrl.toString() !== "") {
                         mouseArea.cursorShape = Qt.PointingHandCursor;


### PR DESCRIPTION
Adds support for SSL client certificates, usually used for mTLS purposes. 
Works great on my machine for accessing Home Assistant through nginx. 
You do first need to [add the certificates to your user store](https://wiki.archlinux.org/title/Network_Security_Services#Import_certificate) before they can be used here. 
The format for the settings entry is `Issuer Name|Common Name`